### PR TITLE
can only clean up ext after a bundle install since the build artifacts c...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.5
-
+branches:
+  only: master

--- a/lib/dockerb.rb
+++ b/lib/dockerb.rb
@@ -26,7 +26,7 @@ module Dockerb
           ADD Gemfile /app/
           ADD Gemfile.lock /app/
           ADD vendor/cache /app/vendor/cache
-          RUN (bundle install --quiet --local --jobs 4 || bundle check) && #{delete_gem_junk}
+          RUN (bundle install --quiet --local --jobs 4 || bundle check) && #{delete_gem_junk ext: true}
         EOF
       end
 
@@ -37,8 +37,8 @@ module Dockerb
       end
 
       # lower image size by not shipping test/spec/ext files
-      def delete_gem_junk
-        %{find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2 -name "ext" -o -name "test" -o -name "spec" | xargs rm -r}
+      def delete_gem_junk(options={})
+        %{find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2#{' -name "ext"' if options[:ext]} -o -name "test" -o -name "spec" | xargs rm -r}
       end
     end
   end

--- a/spec/dockerb_spec.rb
+++ b/spec/dockerb_spec.rb
@@ -49,12 +49,12 @@ describe Dockerb do
 
       it "generates gem install commands" do
         File.write("Gemfile.lock", "  nokogiri (~> 1.2.3)\n      nokogiri (2.3.4)\n    nokogiri (3.4.5)")
-        call("<%= install_gem 'nokogiri' %>").should == %{RUN gem install -v 3.4.5 nokogiri && find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2 -name "ext" -o -name "test" -o -name "spec" | xargs rm -r}
+        call("<%= install_gem 'nokogiri' %>").should == %{RUN gem install -v 3.4.5 nokogiri && find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2 -o -name "test" -o -name "spec" | xargs rm -r}
       end
 
       it "generates gem install command with args" do
         File.write("Gemfile.lock", "  nokogiri (~> 1.2.3)\n      nokogiri (2.3.4)\n    nokogiri (3.4.5)")
-        call("<%= install_gem 'nokogiri', '--foobar' %>").should == %{RUN gem install -v 3.4.5 nokogiri --foobar && find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2 -name "ext" -o -name "test" -o -name "spec" | xargs rm -r}
+        call("<%= install_gem 'nokogiri', '--foobar' %>").should == %{RUN gem install -v 3.4.5 nokogiri --foobar && find /usr/local/lib/ruby/gems/*/gems/ -maxdepth 2 -o -name "test" -o -name "spec" | xargs rm -r}
       end
 
       it "fails when it cannot find a gem in the Gemfile.lock" do


### PR DESCRIPTION
...an be reused by other gems during install

other issues could pop up after a bundle install when trying to install gems by hand ... but then you could just re-install nokogiri for example

```
/usr/local/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- /usr/local/lib/ruby/gems/2.1.0/gems/nokogiri-1.6.3.1/ext/nokogiri/extconf.rb (LoadError)
    from /usr/local/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from extconf.rb:17:in `<main>'
```
